### PR TITLE
chore: shrink sidebar

### DIFF
--- a/app/[chain]/news/[year]/[month]/[week]/page.tsx
+++ b/app/[chain]/news/[year]/[month]/[week]/page.tsx
@@ -94,12 +94,12 @@ export default async function ChainNewsPage({ params }: Props) {
       {/* Main content */}
       <div className="w-full item-center justify-center py-4 px-3 sm:px-6 md:px-8 flex flex-col min-[981px]:flex-row min-[981px]:gap-6 mx-auto max-w-screen-xl">
         {/* Desktop sidebar - hidden at 980px and below */}
-        <div className="hidden min-[981px]:block min-[981px]:w-64 lg:w-72 min-[981px]:-ml-2 flex-shrink-0">
+        <div className="hidden min-[981px]:block min-[981px]:w-24 min-[981px]:-ml-2 flex-shrink-0">
           <Sidebar newsGroups={newsGroups} chainId={chain} />
         </div>
 
         {/* Weekly news content */}
-        <div className="flex-grow w-full min-[981px]:w-[calc(100%-280px)] lg:w-[calc(100%-300px)] max-w-4xl">
+        <div className="flex-grow w-full min-[981px]:w-[calc(100%-96px)] max-w-4xl">
           <WeeklyNewsContent
             dateRangeTitle={dateRangeTitle}
             groupedItems={groupedItems}

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -18,19 +18,19 @@ export function Sidebar({
 }: SidebarProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const [expandedMonth, setExpandedMonth] = useState<string | null>(null);
+  const [expandedYear, setExpandedYear] = useState<number | null>(null);
 
   useEffect(() => {
-    // Extract current year and month from pathname
+    // Extract current year from pathname
     const match = pathname.match(/\/(\d+)\/(\d+)\/(\d+)$/);
     if (match) {
-      const [, year, month] = match;
-      setExpandedMonth(`${year}-${month}`);
+      const [, year] = match;
+      setExpandedYear(parseInt(year));
     }
   }, [pathname]);
 
-  const toggleMonth = (yearMonth: string) => {
-    setExpandedMonth(prev => prev === yearMonth ? null : yearMonth);
+  const toggleYear = (year: number) => {
+    setExpandedYear(current => current === year ? null : year);
   };
 
   const navigateToWeek = (year: number, month: number, week: number) => {
@@ -40,75 +40,55 @@ export function Sidebar({
 
   const getWeekDates = (year: number, month: number, week: number) => {
     const startDay = new Date(year, month - 1, (week - 1) * 7 + 1);
-    const endDay = new Date(year, month - 1, week * 7);
-    
-    // Handle edge case where week extends to next month
-    if (endDay.getMonth() !== month - 1) {
-      endDay.setDate(0); // Last day of the month
-    }
-
-    const startDate = startDay.getDate().toString().padStart(2, '0');
-    const endDate = endDay.getDate().toString().padStart(2, '0');
-    const startMonth = startDay.toLocaleString('default', { month: 'short' });
-    const endMonth = endDay.toLocaleString('default', { month: 'short' });
-
-    if (startMonth === endMonth) {
-      return `${startDate}-${endDate}`;
-    }
-    return `${startDate}-${endDate}`;
+    return startDay.toLocaleString('default', { month: 'short', day: 'numeric' });
   };
 
   return (
     <div className="w-24 h-full rounded-xl bg-light-panel">
       <ScrollArea className="h-[calc(100vh-6rem)]">
         <div className="flex flex-col items-center py-3 space-y-4">
-          {newsGroups.map(({ year, months }) => (
-            <div key={year} className="flex flex-col items-center space-y-2">
-              <span className="text-sm font-semibold text-muted-foreground">{year}</span>
-              {months.map(({ month, weeks }) => {
-                const yearMonth = `${year}-${month}`;
-                const isExpanded = expandedMonth === yearMonth;
-                const weekPath = `/${chainId.toLowerCase()}/news/${year}/${month}/${weeks[0]?.week}`;
-                const isCurrentMonth = pathname.startsWith(weekPath);
-                
-                return (
-                  <div key={month} className="flex flex-col items-center space-y-1">
-                    <button
-                      onClick={() => toggleMonth(yearMonth)}
-                      className={cn(
-                        "text-xs text-muted-foreground hover:text-primary transition-colors",
-                        (isExpanded || isCurrentMonth) && "text-primary"
-                      )}
-                    >
-                      {new Date(year, month - 1).toLocaleString('default', { month: 'short' })}
-                    </button>
-                    {(isExpanded || isCurrentMonth) && (
-                      <div className="flex flex-col items-center space-y-1 mt-1">
-                        {weeks.map(({ week }) => {
-                          const weekPath = `/${chainId.toLowerCase()}/news/${year}/${month}/${week}`;
-                          const isActive = pathname === weekPath;
-                          return (
-                            <Button
-                              key={week}
-                              variant="ghost"
-                              size="sm"
-                              className={cn(
-                                "h-6 w-16 p-0 text-xs hover:bg-accent",
-                                isActive && "bg-primary/10 text-primary"
-                              )}
-                              onClick={() => navigateToWeek(year, month, week)}
-                            >
-                              {getWeekDates(year, month, week)}
-                            </Button>
-                          );
-                        })}
-                      </div>
+          {newsGroups.map(({ year, months }) => {
+            const isExpanded = expandedYear === year;
+            const isCurrentYear = pathname.includes(`/${year}/`);
+            
+            return (
+              <div key={year} className="flex flex-col items-center space-y-2">
+                <button
+                  onClick={() => toggleYear(year)}
+                  className={cn(
+                    "text-sm font-semibold text-muted-foreground hover:text-primary transition-colors",
+                    (isExpanded || isCurrentYear) && "text-primary"
+                  )}
+                >
+                  {year}
+                </button>
+                {(isExpanded || isCurrentYear) && (
+                  <div className="flex flex-col items-center space-y-1">
+                    {months.flatMap(({ month, weeks }) =>
+                      weeks.map(({ week }) => {
+                        const weekPath = `/${chainId.toLowerCase()}/news/${year}/${month}/${week}`;
+                        const isActive = pathname === weekPath;
+                        return (
+                          <Button
+                            key={`${month}-${week}`}
+                            variant="ghost"
+                            size="sm"
+                            className={cn(
+                              "h-6 w-16 p-0 text-xs hover:bg-accent",
+                              isActive && "bg-primary/10 text-primary"
+                            )}
+                            onClick={() => navigateToWeek(year, month, week)}
+                          >
+                            {getWeekDates(year, month, week)}
+                          </Button>
+                        );
+                      })
                     )}
                   </div>
-                );
-              })}
-            </div>
-          ))}
+                )}
+              </div>
+            );
+          })}
         </div>
       </ScrollArea>
     </div>

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { YearItem } from "./year-item";
 import { NewsGroup, Chain } from "@/app/types";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface SidebarProps {
   newsGroups: NewsGroup[];
@@ -41,37 +42,64 @@ export function Sidebar({
     setExpandedYears(recentYears);
   }, []);
 
-  const toggleYear = (year: number) => {
-    setExpandedYears((prev) =>
-      prev.includes(year) ? prev.filter((y) => y !== year) : [...prev, year]
-    );
+  const navigateToWeek = (year: number, month: number, week: number) => {
+    const chainPath = chainId.toLowerCase();
+    router.push(`/${chainPath}/news/${year}/${month}/${week}`);
   };
 
-  const toggleMonth = (yearMonth: string) => {
-    setExpandedMonths((prev) =>
-      prev.includes(yearMonth)
-        ? prev.filter((ym) => ym !== yearMonth)
-        : [...prev, yearMonth]
-    );
+  const getWeekDates = (year: number, month: number, week: number) => {
+    const startDay = new Date(year, month - 1, (week - 1) * 7 + 1);
+    const endDay = new Date(year, month - 1, week * 7);
+    
+    // Handle edge case where week extends to next month
+    if (endDay.getMonth() !== month - 1) {
+      endDay.setDate(0); // Last day of the month
+    }
+
+    const startDate = startDay.getDate();
+    const endDate = endDay.getDate();
+    const startMonth = startDay.toLocaleString('default', { month: 'short' });
+    const endMonth = endDay.toLocaleString('default', { month: 'short' });
+
+    if (startMonth === endMonth) {
+      return `${startDate}-${endDate}`;
+    }
+    return `${startDate}-${endDate}`;
   };
 
   return (
-    <div className="w-full md:w-64 h-full rounded-xl bg-light-panel">
+    <div className="w-24 h-full rounded-xl bg-light-panel">
       <ScrollArea className="h-[calc(100vh-6rem)]">
-        <div className="px-2 py-3">
+        <div className="flex flex-col items-center py-3 space-y-4">
           {newsGroups.map(({ year, months }) => (
-            <YearItem
-              key={year}
-              year={year}
-              months={months}
-              isExpanded={expandedYears.includes(year)}
-              onToggle={toggleYear}
-              expandedMonths={expandedMonths}
-              toggleMonth={toggleMonth}
-              pathname={pathname}
-              router={router}
-              chainId={chainId}
-            />
+            <div key={year} className="flex flex-col items-center space-y-2">
+              <span className="text-sm font-semibold text-muted-foreground">{year}</span>
+              {months.map(({ month, weeks }) => (
+                <div key={month} className="flex flex-col items-center space-y-1">
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(year, month - 1).toLocaleString('default', { month: 'short' })}
+                  </span>
+                  {weeks.map(({ week }) => {
+                    const weekPath = `/${chainId.toLowerCase()}/news/${year}/${month}/${week}`;
+                    const isActive = pathname === weekPath;
+                    return (
+                      <Button
+                        key={week}
+                        variant="ghost"
+                        size="sm"
+                        className={cn(
+                          "h-6 w-16 p-0 text-xs hover:bg-accent",
+                          isActive && "bg-primary/10 text-primary"
+                        )}
+                        onClick={() => navigateToWeek(year, month, week)}
+                      >
+                        {getWeekDates(year, month, week)}
+                      </Button>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
           ))}
         </div>
       </ScrollArea>


### PR DESCRIPTION
- replace the chonky sidebar with a thinner one
- ensure the relevant info is still available
- ensure display works on mobile

Follow up idea: 
- we could shrink the weeks and show only months under the year 
- folks can click on the month to get dates

This is under the assumption that folks will likely read the latest news and wouldn't mind a cleaner UI and doing an extra click to get the older week info

