### PR TITLE
feat: add perma link to the news item

### DIFF
--- a/app/components/news-list.tsx
+++ b/app/components/news-list.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import {
   ExternalLink,
   Share2,
   Calendar,
   Twitter,
   MessageCircle,
+  CheckCircle2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { NewsItem } from "../types";
+import { useToast } from "@/hooks/use-toast";
+import { Toaster } from "@/components/ui/toaster";
 
 interface NewsListProps {
   items: NewsItem[];
@@ -18,6 +21,34 @@ interface NewsListProps {
 }
 
 export function NewsList({ items, category }: NewsListProps) {
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash) {
+      const element = document.getElementById(hash.slice(1));
+      if (element) {
+        setTimeout(() => {
+          element.scrollIntoView({ behavior: "smooth" });
+        }, 100);
+      }
+    }
+  }, []);
+
+  const copyNewsLink = (item: NewsItem, index: number) => {
+    const categorySlug = category?.toLowerCase().replace(/\s+/g, '-') || 'news';
+    const url = `${window.location.origin}${window.location.pathname}#${categorySlug}-${index + 1}`;
+    navigator.clipboard.writeText(url);
+    toast({
+      description: (
+        <div className="flex items-center gap-2">
+          <CheckCircle2 className="h-4 w-4 text-green-500" />
+          <span>Link copied to clipboard!</span>
+        </div>
+      ),
+    });
+  };
+
   const shareNews = (item: NewsItem) => {
     const text = `${item.headline} - Read more about Ethereum news`;
     window.open(
@@ -36,22 +67,6 @@ export function NewsList({ items, category }: NewsListProps) {
       )}&text=${encodeURIComponent(text)}`,
       "_blank"
     );
-  };
-
-  const handleNativeShare = async (item: NewsItem) => {
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: item.headline,
-          text: `Check out this blockchain news: ${item.headline}`,
-          url: item.link,
-        });
-      } catch (err) {
-        console.log("Error sharing:", err);
-      }
-    } else {
-      shareNews(item);
-    }
   };
 
   const shareWeeklyNews = () => {
@@ -98,6 +113,7 @@ export function NewsList({ items, category }: NewsListProps) {
 
   return (
     <div className="bg-light-panel px-3 sm:px-4 md:px-6 py-4 md:py-8">
+      <Toaster />
       <div className="mx-auto max-w-4xl" style={{ width: "100%" }}>
         <div className="mb-4 md:mb-6 flex items-center justify-between">
           <div className="flex items-center">
@@ -149,72 +165,84 @@ export function NewsList({ items, category }: NewsListProps) {
         </div>
 
         <div className="grid gap-4 md:gap-6">
-          {items.map((item, index) => (
-            <div
-              key={item.id}
-              id={`news-${item.id}`}
-              className="group glass-card rounded-xl p-3 sm:p-4 md:p-6 transition-all duration-500 hover:shadow-[0_8px_32px_rgba(0,0,0,0.12)] hover:-translate-y-1 animate-in fade-in slide-in-from-bottom-2"
-              style={{ animationDelay: `${index * 50}ms` }}
-            >
-              <h3 className="text-base md:text-lg font-medium mb-2 md:mb-4 group-hover:text-primary transition-colors duration-300">
-                {item.headline}
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed mb-3 md:mb-4">
-                {item.summary}
-              </p>
+          {items.map((item, index) => {
+            const categorySlug = category?.toLowerCase().replace(/\s+/g, '-') || 'news';
+            const itemId = `${categorySlug}-${index + 1}`;
+            
+            return (
+              <div
+                key={item.id}
+                id={itemId}
+                className="group glass-card rounded-xl p-3 sm:p-4 md:p-6 transition-all duration-500 hover:shadow-[0_8px_32px_rgba(0,0,0,0.12)] hover:-translate-y-1 animate-in fade-in slide-in-from-bottom-2 scroll-mt-20"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <a
+                  href={item.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block"
+                >
+                  <h3 className="text-base md:text-lg font-medium mb-2 md:mb-4 group-hover:text-primary transition-colors duration-300">
+                    {item.headline}
+                  </h3>
+                </a>
+                <p className="text-sm text-muted-foreground leading-relaxed mb-3 md:mb-4">
+                  {item.summary}
+                </p>
 
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mt-2 md:mt-4">
-                <div className="flex items-center text-xs text-muted-foreground">
-                  <span>Source: </span>
-                  <a
-                    href={item.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="ml-1 flex items-center text-primary/80 hover:text-primary transition-colors duration-300 group/link"
-                  >
-                    {new URL(item.link).hostname.replace("www.", "")}
-                    <ExternalLink className="ml-1 h-3 w-3 transition-transform duration-300 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5" />
-                  </a>
-                </div>
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mt-2 md:mt-4">
+                  <div className="flex items-center text-xs text-muted-foreground">
+                    <span>Source: </span>
+                    <a
+                      href={item.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1 flex items-center text-primary/80 hover:text-primary transition-colors duration-300 group/link"
+                    >
+                      {new URL(item.link).hostname.replace("www.", "")}
+                      <ExternalLink className="ml-1 h-3 w-3 transition-transform duration-300 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5" />
+                    </a>
+                  </div>
 
-                <div className="flex items-center gap-1 md:gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 md:h-9 md:w-auto px-1 md:px-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors duration-300"
-                    onClick={() => shareNews(item)}
-                  >
-                    <Twitter className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
-                    <span className="sr-only md:not-sr-only md:inline text-xs">
-                      Twitter
-                    </span>
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 md:h-9 md:w-auto px-1 md:px-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors duration-300"
-                    onClick={() => shareToTelegram(item)}
-                  >
-                    <MessageCircle className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
-                    <span className="sr-only md:not-sr-only md:inline text-xs">
-                      Telegram
-                    </span>
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 md:h-9 md:w-auto px-1 md:px-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors duration-300"
-                    onClick={() => handleNativeShare(item)}
-                  >
-                    <Share2 className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
-                    <span className="sr-only md:not-sr-only md:inline text-xs">
-                      Share
-                    </span>
-                  </Button>
+                  <div className="flex items-center gap-1 md:gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 md:h-9 md:w-auto px-1 md:px-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors duration-300"
+                      onClick={() => shareNews(item)}
+                    >
+                      <Twitter className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
+                      <span className="sr-only md:not-sr-only md:inline text-xs">
+                        Twitter
+                      </span>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 md:h-9 md:w-auto px-1 md:px-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors duration-300"
+                      onClick={() => shareToTelegram(item)}
+                    >
+                      <MessageCircle className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
+                      <span className="sr-only md:not-sr-only md:inline text-xs">
+                        Telegram
+                      </span>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 md:h-9 md:w-auto px-1 md:px-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors duration-300"
+                      onClick={() => copyNewsLink(item, index)}
+                    >
+                      <Share2 className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
+                      <span className="sr-only md:not-sr-only md:inline text-xs">
+                        Share
+                      </span>
+                    </Button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
- generated custom link to every news
- when you click on the title of the news -> it takes you to the source
- when you click on the share button within the news -> it simply copies the perma link to the clipboard

Open question @0xKurt : 
- when you click share on twitter / telegram -> should we share the source link or the permalink on latest block ?

![Deploy](https://github.com/user-attachments/assets/8a763e86-e257-46ce-8ce4-6d9387b282fa)
